### PR TITLE
Fix bugs in if selections of fingerprint_file functions.

### DIFF
--- a/src/blindelephant/Fingerprinters.py
+++ b/src/blindelephant/Fingerprinters.py
@@ -99,7 +99,7 @@ class WebAppFingerprinter(object):
             self._host_down_errors = 0
             hash = hashlib.md5(data + path).hexdigest()
             
-            if self.path_nodes.has_key(hash):
+            if self.path_nodes[path].has_key(hash):
                 possible_vers = self.path_nodes[path][hash]
                 self.logger.logFileHit(path, possible_vers, None, None, False)
                 return possible_vers
@@ -252,7 +252,7 @@ class WebAppGuesser(object):
             self._host_down_errors = 0
             hash = hashlib.md5(data + path).hexdigest()
             
-            if path_nodes.has_key(hash):
+            if path_nodes[path].has_key(hash):
                 possible_vers = path_nodes[path][hash]
                 self.logger.logFileHit(path, possible_vers, None, None, False)
                 return possible_vers


### PR DESCRIPTION
Found a small error in the fingperprint_file function of Fingerprinters.py.
In the selection, path_nodes is not used correctly, and program will go to the else block no matter what. This could cause some potentials cases where sites might need extra manipulation in else block or couldn't be fingerprinted at all.